### PR TITLE
feat: transitive dependencies

### DIFF
--- a/__tests__/fixtures/b.styl
+++ b/__tests__/fixtures/b.styl
@@ -1,0 +1,1 @@
+@import './a.styl';

--- a/__tests__/get-dependencies.spec.ts
+++ b/__tests__/get-dependencies.spec.ts
@@ -1,0 +1,19 @@
+import { getDependencies } from '../src/get-dependencies';
+import { readFileSync } from 'fs';
+import path from "path";
+
+describe('test src/get-dependencies.ts', () => {
+  it('uses stylus.deps() to get the imports of a file', () => {
+    const filePath = path.join(__dirname, './fixtures/b.styl');
+    const content = readFileSync(filePath, 'utf-8');
+    const dependencies = getDependencies({
+      content,
+      filePath,
+      options: {}
+    });
+
+    expect(dependencies).toStrictEqual([
+      path.join(__dirname, './fixtures/a.styl')
+    ]);
+  });
+});

--- a/src/get-dependencies.ts
+++ b/src/get-dependencies.ts
@@ -1,0 +1,15 @@
+import stylus from 'stylus';
+import { Options } from './interface';
+
+export function getDependencies({
+  content,
+  filePath,
+  options,
+}: {
+  content: string;
+  filePath: string;
+  options: Options;
+}): string[] {
+  const style = stylus(content, { filename: filePath, ...options });
+  return style.deps(filePath);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,35 @@ import * as fs from 'fs';
 import { SnowpackPluginFactory } from 'snowpack';
 import { Options } from './interface';
 import { render } from './render';
+import { getDependencies } from './get-dependencies';
 
 const pkg = require('../package.json');
 
 const plugin: SnowpackPluginFactory<Options> = (snowpackConfig, options = {}) => {
+  const importedByMap = new Map<string, string[]>();
+
+  function addDependencies(filePath: string, dependencies: string[]) {
+    dependencies.forEach((file) => {
+      const currentImports = importedByMap.get(filePath) || [];
+      importedByMap.set(file, currentImports.concat(filePath));
+    });
+  }
+
   return {
     name: pkg.name,
     resolve: {
       input: ['.styl'],
       output: ['.css'],
     },
+    onChange({ filePath }) {
+      const filesToMark = importedByMap.get(filePath) || [];
+      filesToMark.forEach((file) => this.markChanged && this.markChanged(file));
+    },
     async load({ filePath }) {
       try {
         const content = await fs.promises.readFile(filePath, 'utf-8');
+        const dependencies = getDependencies({ content, filePath, options });
+        addDependencies(filePath, dependencies);
         const result = await render(content, {
           ...options,
           filename: filePath,


### PR DESCRIPTION
Implements https://github.com/fansenze/snowpack-plugin-stylus/issues/8

The approach is similar to the one found in the sass plugin, but way simpler, as we don't need to rely on regex to parse the imports. Stylus offers a convenient way to get all dependencies of a file. This also includes transitive dependencies.

These dependencies are added to a map whenever a file is loaded. Whenever one of these files is changed, we mark all files importing it as changed, thus triggering a live reload.